### PR TITLE
 UI changes:

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -8,10 +8,10 @@
             <InsightsFilterSettings>
               <option name="connection">
                 <ConnectionSetting>
-                  <option name="appId" value="PLACEHOLDER" />
-                  <option name="mobileSdkAppId" value="" />
-                  <option name="projectId" value="" />
-                  <option name="projectNumber" value="" />
+                  <option name="appId" value="com.darsh.news" />
+                  <option name="mobileSdkAppId" value="1:862299672631:android:b5b09bce4fed311c012fb2" />
+                  <option name="projectId" value="depi-news" />
+                  <option name="projectNumber" value="862299672631" />
                 </ConnectionSetting>
               </option>
               <option name="signal" value="SIGNAL_UNSPECIFIED" />

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -70,6 +70,8 @@ dependencies {
     implementation(libs.glide)
 
     implementation (libs.androidx.swiperefreshlayout)
+    implementation ("androidx.navigation:navigation-fragment:2.9.3")
+
 
     implementation("androidx.datastore:datastore-preferences:1.1.1")
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,8 +5,6 @@
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
-
-        android:usesCleartextTraffic="true"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -15,9 +13,14 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.News"
+        android:usesCleartextTraffic="true"
         tools:targetApi="31">
         <activity
             android:name=".MainActivity"
+            android:exported="false" />
+
+        <activity
+            android:name=".homeActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -25,7 +28,6 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-    </application
->
+    </application>
 
 </manifest>

--- a/app/src/main/java/com/darsh/news/homeActivity.kt
+++ b/app/src/main/java/com/darsh/news/homeActivity.kt
@@ -1,0 +1,20 @@
+package com.darsh.news
+
+import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+
+class homeActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
+        setContentView(R.layout.activity_home)
+        ViewCompat.setOnApplyWindowInsetsListener(findViewById(R.id.main)) { v, insets ->
+            val systemBars = insets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.setPadding(systemBars.left, systemBars.top, systemBars.right, systemBars.bottom)
+            insets
+        }
+    }
+}

--- a/app/src/main/java/com/darsh/news/presentation/authentication/SignInFragment.kt
+++ b/app/src/main/java/com/darsh/news/presentation/authentication/SignInFragment.kt
@@ -41,37 +41,40 @@ class SignInFragment : Fragment() {
         }
         binding.buttonSignIn.setOnClickListener {
             if (isInputValid()) {
-                it.findNavController().navigate(R.id.action_signInFragment_to_favouritFragment)
+                it.findNavController().navigate(R.id.action_signInFragment_to_homeFragment)
             }
-        }    }
-private fun isInputValid(): Boolean {
-    // Clear previous errors before running validation
-    clearErrors()
-
-    val email = binding.inputEmail.text.toString().trim()
-    val password = binding.inputPassword.text.toString()
-    var isValid = true
-
-    // 2. Email Validation
-    if (email.isBlank()) {
-        binding.layoutEmail.error = "Email is required"
-        isValid = false
-    } else if (!android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
-        binding.layoutEmail.error = "Invalid email format"
-        isValid = false
+        }
     }
 
-    // 3. Password Validation (Length)
-    if (password.isBlank()) {
-        binding.layoutPassword.error = "Password is required"
-        isValid = false
+    private fun isInputValid(): Boolean {
+        // Clear previous errors before running validation
+        clearErrors()
+
+        val email = binding.inputEmail.text.toString().trim()
+        val password = binding.inputPassword.text.toString()
+        var isValid = true
+
+        // 2. Email Validation
+        if (email.isBlank()) {
+            binding.layoutEmail.error = "Email is required"
+            isValid = false
+        } else if (!android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+            binding.layoutEmail.error = "Invalid email format"
+            isValid = false
+        }
+
+        // 3. Password Validation (Length)
+        if (password.isBlank()) {
+            binding.layoutPassword.error = "Password is required"
+            isValid = false
+        }
+
+        return isValid
     }
 
-    return isValid
+    // Helper function to clear all active errors on TextInputLayouts
+    private fun clearErrors() {
+        binding.layoutEmail.error = null
+        binding.layoutPassword.error = null
+    }
 }
-
-// Helper function to clear all active errors on TextInputLayouts
-private fun clearErrors() {
-    binding.layoutEmail.error = null
-    binding.layoutPassword.error = null
-}}

--- a/app/src/main/java/com/darsh/news/presentation/authentication/SignInFragment.kt
+++ b/app/src/main/java/com/darsh/news/presentation/authentication/SignInFragment.kt
@@ -1,0 +1,77 @@
+package com.darsh.news.presentation.authentication
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.navigation.findNavController
+import com.darsh.news.R
+import com.darsh.news.databinding.FragmentSignInBinding
+
+// TODO: Rename parameter arguments, choose names that match
+// the fragment initialization parameters, e.g. ARG_ITEM_NUMBER
+private const val ARG_PARAM1 = "param1"
+private const val ARG_PARAM2 = "param2"
+
+/**
+ * A simple [Fragment] subclass.
+ * Use the [SignInFragment.newInstance] factory method to
+ * create an instance of this fragment.
+ */
+class SignInFragment : Fragment() {
+
+    lateinit var binding: FragmentSignInBinding
+
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+        binding = FragmentSignInBinding.inflate(inflater, container, false)
+
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        binding.textRegisterFull.setOnClickListener {
+            it.findNavController().navigate(R.id.action_signInFragment_to_signUpFragment2)
+        }
+        binding.buttonSignIn.setOnClickListener {
+            if (isInputValid()) {
+                it.findNavController().navigate(R.id.action_signInFragment_to_favouritFragment)
+            }
+        }    }
+private fun isInputValid(): Boolean {
+    // Clear previous errors before running validation
+    clearErrors()
+
+    val email = binding.inputEmail.text.toString().trim()
+    val password = binding.inputPassword.text.toString()
+    var isValid = true
+
+    // 2. Email Validation
+    if (email.isBlank()) {
+        binding.layoutEmail.error = "Email is required"
+        isValid = false
+    } else if (!android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+        binding.layoutEmail.error = "Invalid email format"
+        isValid = false
+    }
+
+    // 3. Password Validation (Length)
+    if (password.isBlank()) {
+        binding.layoutPassword.error = "Password is required"
+        isValid = false
+    }
+
+    return isValid
+}
+
+// Helper function to clear all active errors on TextInputLayouts
+private fun clearErrors() {
+    binding.layoutEmail.error = null
+    binding.layoutPassword.error = null
+}}

--- a/app/src/main/java/com/darsh/news/presentation/authentication/SignUpFragment.kt
+++ b/app/src/main/java/com/darsh/news/presentation/authentication/SignUpFragment.kt
@@ -1,0 +1,103 @@
+package com.darsh.news.presentation.authentication
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.navigation.fragment.findNavController
+import com.darsh.news.R
+import com.darsh.news.databinding.FragmentSignUpBinding
+
+class SignUpFragment : Fragment() {
+
+
+    private lateinit var binding: FragmentSignUpBinding
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        // Inflate the layout for this fragment using View Binding
+        binding = FragmentSignUpBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        // Link the Sign Up button to the validation function
+        binding.buttonSignUp.setOnClickListener {
+            if (isInputValid()) {
+                // Navigate only if all inputs are valid
+                findNavController().navigate(R.id.action_signUpFragment2_to_signInFragment)
+            }
+        }
+
+        // Link the Sign In link to navigation
+        binding.textSignInFull.setOnClickListener {
+            findNavController().navigate(R.id.action_signUpFragment2_to_signInFragment)
+        }
+    }
+
+    /**
+     * Checks all input fields for validity and displays specific error messages.
+     * @return true if all fields pass validation, false otherwise.
+     */
+    private fun isInputValid(): Boolean {
+        // Clear previous errors before running validation
+        clearErrors()
+
+        val email = binding.inputEmail.text.toString().trim()
+        val username = binding.inputName.text.toString().trim()
+        val password = binding.inputPassword.text.toString()
+        val confirmPassword = binding.inputConfirmPassword.text.toString()
+
+        var isValid = true
+
+        // 1. Username Validation
+        if (username.isBlank()) {
+            binding.layoutName.error = "Name is required"
+            isValid = false
+        }
+
+        // 2. Email Validation
+        if (email.isBlank()) {
+            binding.layoutEmail.error = "Email is required"
+            isValid = false
+        } else if (!android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches()) {
+            binding.layoutEmail.error = "Invalid email format"
+            isValid = false
+        }
+
+        // 3. Password Validation (Length)
+        if (password.isBlank()) {
+            binding.layoutPassword.error = "Password is required"
+            isValid = false
+        } else if (password.length < 6) {
+            binding.layoutPassword.error = "Must be at least 6 characters"
+            isValid = false
+        }
+
+        // 4. Confirm Password Validation (Required & Match)
+        if (confirmPassword.isBlank()) {
+            binding.layoutConfirmPassword.error = "Confirmation is required"
+            isValid = false
+        } else if (password != confirmPassword) {
+            // Error messages for both fields to highlight the mismatch
+            binding.layoutPassword.error = "Passwords do not match"
+            binding.layoutConfirmPassword.error = "Passwords do not match"
+            isValid = false
+        }
+
+        return isValid
+    }
+
+    // Helper function to clear all active errors on TextInputLayouts
+    private fun clearErrors() {
+        binding.layoutName.error = null
+        binding.layoutEmail.error = null
+        binding.layoutPassword.error = null
+        binding.layoutConfirmPassword.error = null
+    }
+}

--- a/app/src/main/java/com/darsh/news/presentation/home/HomeFragment.kt
+++ b/app/src/main/java/com/darsh/news/presentation/home/HomeFragment.kt
@@ -1,0 +1,31 @@
+package com.darsh.news.presentation.home
+
+import androidx.fragment.app.viewModels
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.darsh.news.R
+
+class HomeFragment : Fragment() {
+
+    companion object {
+        fun newInstance() = HomeFragment()
+    }
+
+    private val viewModel: HomeViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // TODO: Use the ViewModel
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_home, container, false)
+    }
+}

--- a/app/src/main/java/com/darsh/news/presentation/home/HomeViewModel.kt
+++ b/app/src/main/java/com/darsh/news/presentation/home/HomeViewModel.kt
@@ -1,0 +1,7 @@
+package com.darsh.news.presentation.home
+
+import androidx.lifecycle.ViewModel
+
+class HomeViewModel : ViewModel() {
+    // TODO: Implement the ViewModel
+}

--- a/app/src/main/java/com/darsh/news/presentation/newsList/NewsFragment.kt
+++ b/app/src/main/java/com/darsh/news/presentation/newsList/NewsFragment.kt
@@ -1,77 +1,93 @@
-//package com.darsh.news.presentation
-//
-//import androidx.fragment.app.viewModels
-//import android.os.Bundle
-//import android.util.Log
-//import androidx.fragment.app.Fragment
-//import android.view.LayoutInflater
-//import android.view.View
-//import android.view.ViewGroup
-//import androidx.core.view.isVisible
-//import com.darsh.news.R
-//import com.darsh.news.data.remote.api.news.NewsCallable
-//import com.darsh.news.data.remote.data_model.Article
-//import com.darsh.news.data.remote.data_model.News
-//import com.darsh.news.databinding.FragmentNewsBinding
-//import retrofit2.Call
-//import retrofit2.Callback
-//import retrofit2.Response
-//import retrofit2.Retrofit
-//import retrofit2.converter.gson.GsonConverterFactory
-//
-//class NewsFragment : Fragment() {
-//
-//    companion object {
-//        fun newInstance() = NewsFragment()
-//    }
-//
-//    private val viewModel: NewsViewModel by viewModels()
-//
-//    private lateinit var binding: FragmentNewsBinding
-//
-//    override fun onCreate(savedInstanceState: Bundle?) {
-//        super.onCreate(savedInstanceState)
-//
-//        viewModel.getNews()
-//    }
-//
-//    private fun getNews() {
-//        val retrofit = Retrofit
-//            .Builder()
-//            .baseUrl("https://newsapi.org")
-//            .addConverterFactory(GsonConverterFactory.create())
-//            .build()
-//
-//        val newsCall = retrofit.create(NewsCallable::class.java)
-//        newsCall.getNews().enqueue(object :
-//            Callback<News> {
-//            override fun onResponse(call: Call<News>, response: Response<News>) {
-//                val news = response.body()
-//                val articles = news?.articles!!
-//                Log.d("FetchNewsListUseCase", news.toString())
-//                binding.progressCircular.isVisible=false
-//                showNews(articles = articles )
-//            }
-//
-//            override fun onFailure(call: Call<News>, t: Throwable) {
-//                Log.e("FetchNewsListUseCase", t.toString())
-//                binding.progressCircular.isVisible=false
-//
-//            }
-//        })
-//    }
-//
-//    private fun showNews(articles: Array<Article>) {
-//       // val adapter = NewsAdapter(context,articles)
-//        //binding.newsList.adapter=adapter
-//
-//    }
-//
-//    override fun onCreateView(
-//        inflater: LayoutInflater, container: ViewGroup?,
-//        savedInstanceState: Bundle?
-//    ): View {
-//        binding = FragmentNewsBinding.inflate(inflater, container, false)
-//        return binding.root
-//    }
-//}
+package com.darsh.news.presentation.newsList
+
+import android.app.Activity
+import android.os.Bundle
+import android.util.Log
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import com.darsh.news.data.remote.api.news.NewsCallable
+import com.darsh.news.data.remote.data_model.Article
+import com.darsh.news.data.remote.data_model.News
+import com.darsh.news.databinding.FragmentNewsBinding
+import com.darsh.news.presentation.NewsAdapter
+import com.darsh.news.presentation.NewsViewModel
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+
+class NewsFragment : Fragment() {
+
+    private val viewModel: NewsViewModel by viewModels()
+    private lateinit var binding: FragmentNewsBinding
+    private lateinit var newsAdapter: NewsAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        binding = FragmentNewsBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        setupRecyclerView()
+
+        binding.swiperefresh.setOnRefreshListener {
+            getNews()
+        }
+
+        getNews()
+    }
+
+    private fun setupRecyclerView() {
+        newsAdapter = NewsAdapter(requireActivity(), emptyArray())
+        binding.newsList.adapter = newsAdapter
+    }
+
+    private fun getNews() {
+        binding.progressCircular.isVisible = true
+        val retrofit = Retrofit
+            .Builder()
+            .baseUrl("https://newsapi.org")
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+
+        val newsCall = retrofit.create(NewsCallable::class.java)
+        newsCall.getNews().enqueue(object : Callback<News> {
+            override fun onResponse(call: Call<News>, response: Response<News>) {
+                binding.progressCircular.isVisible = false
+                binding.swiperefresh.isRefreshing = false
+                if (response.isSuccessful) {
+                    val news = response.body()
+                    val articles = news?.articles
+                    if (articles != null) {
+                        showNews(articles)
+                    }
+                }
+            }
+
+            override fun onFailure(call: Call<News>, t: Throwable) {
+                Log.e("NewsFragment", "Error fetching news", t)
+                binding.progressCircular.isVisible = false
+                binding.swiperefresh.isRefreshing = false
+            }
+        })
+    }
+
+    private fun showNews(articles: Array<Article>) {
+        // Inside MainActivity.kt
+        val activity : Activity? = getActivity()
+
+        val adapter = NewsAdapter(activity!!, articles)
+        binding.newsList.adapter = adapter
+
+    }
+}

--- a/app/src/main/java/com/darsh/news/presentation/newsList/NewsViewModel.kt
+++ b/app/src/main/java/com/darsh/news/presentation/newsList/NewsViewModel.kt
@@ -1,11 +1,11 @@
-//package com.darsh.news.presentation
-//
-//import androidx.lifecycle.ViewModel
-//import com.darsh.news.domain.FetchNewsListUseCase
-//
-//class NewsViewModel : ViewModel() {
-//
-//     fun getNews(){
-//        FetchNewsListUseCase()
-//    }
-//}
+package com.darsh.news.presentation
+
+import androidx.lifecycle.ViewModel
+import com.darsh.news.domain.FetchNewsListUseCase
+
+class NewsViewModel : ViewModel() {
+
+     fun getNews(){
+        FetchNewsListUseCase()
+    }
+}

--- a/app/src/main/java/com/darsh/news/presentation/newsList/favouritFragment.kt
+++ b/app/src/main/java/com/darsh/news/presentation/newsList/favouritFragment.kt
@@ -1,0 +1,55 @@
+package com.darsh.news.presentation.newsList
+
+import android.os.Bundle
+import android.util.Log
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.view.isVisible
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.navigation.findNavController
+import com.darsh.news.R
+import com.darsh.news.data.remote.data_model.Article
+import com.darsh.news.databinding.FragmentFavouritBinding
+import com.darsh.news.presentation.NewsAdapter
+import kotlinx.coroutines.launch
+import okio.IOException
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.HttpException
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import kotlin.getValue
+
+
+class favouritFragment : Fragment() {
+    lateinit var binding: FragmentFavouritBinding
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        // Inflate the layout for this fragment
+         binding= FragmentFavouritBinding.inflate(inflater,container,false)
+        return binding.root
+    }
+    private lateinit var FavNewsAdapter: NewsAdapter
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        FavNewsAdapter = NewsAdapter(requireActivity(), emptyArray<Article>() )
+
+        binding.newsList.adapter = FavNewsAdapter
+        binding.backBtn.setOnClickListener {
+
+        }
+
+       // observeNewsData()
+
+        //viewModel.fetchNews()
+    }
+
+}

--- a/app/src/main/res/drawable/back_arrow.xml
+++ b/app/src/main/res/drawable/back_arrow.xml
@@ -1,0 +1,8 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:autoMirrored="true" android:height="24dp"
+    android:tint="#00BFFF" android:viewportHeight="960"
+    android:viewportWidth="960" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M400,880L0,480L400,80L471,151L142,480L471,809L400,880Z"/>
+    
+</vector>

--- a/app/src/main/res/layout/activity_home.xml
+++ b/app/src/main/res/layout/activity_home.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main"
+    android:name="androidx.navigation.fragment.NavHostFragment"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    app:defaultNavHost="true"
+    app:navGraph="@navigation/app_nav"
+    tools:context=".homeActivity"
+    tools:layout="@layout/fragment_sign_in">
+</androidx.fragment.app.FragmentContainerView>

--- a/app/src/main/res/layout/fragment_favourit.xml
+++ b/app/src/main/res/layout/fragment_favourit.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".presentation.newsList.favouritFragment">
+
+    <com.google.android.material.appbar.AppBarLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/cardview_light_background"
+            android:theme="@style/ThemeOverlay.Material3.ActionBar"
+            app:title="News App"
+            app:titleTextColor="@color/black" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swiperefresh"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <ProgressBar
+                android:id="@+id/progress_circular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/news_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools:listitem="@layout/article_list_item" />
+
+
+        </FrameLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+<com.google.android.material.floatingactionbutton.FloatingActionButton
+    android:layout_width="wrap_content"
+    android:id="@+id/back_btn"
+    android:layout_height="wrap_content"
+    android:layout_gravity="bottom|end"
+    android:src="@drawable/back_arrow"
+    android:layout_marginBottom="8dp"
+
+    />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".presentation.home.HomeFragment">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:text="Hello" />
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_news.xml
+++ b/app/src/main/res/layout/fragment_news.xml
@@ -3,23 +3,70 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android/tools"
     xmlns:tools1="http://schemas.android.com/tools"
+    android:id="@+id/news_fragment_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/news_fragment_container"
     tools:context=".presentation.NewsFragment">
 
-    <ProgressBar
-        android:id="@+id/progress_circular"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center" />
-
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/news_list"
+    <!-- App Bar -->
+    <com.google.android.material.appbar.AppBarLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-        tools1:listitem="@layout/article_list_item" />
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toTopOf="parent">
 
+        <com.google.android.material.appbar.MaterialToolbar
+            android:id="@+id/toolbar"
+            android:layout_width="match_parent"
+            android:layout_height="?attr/actionBarSize"
+            android:background="@color/cardview_light_background"
+            android:theme="@style/ThemeOverlay.Material3.ActionBar"
+            app:title="News App"
+            app:titleTextColor="@color/black" />
+
+    </com.google.android.material.appbar.AppBarLayout>
+
+    <!--    <androidx.fragment.app.FragmentContainerView-->
+    <!--        android:id="@+id/news_fragment_container"-->
+    <!--        android:name="com.darsh.news.presentation.NewsFragment" -->
+    <!--    android:layout_width="match_parent"-->
+    <!--    android:layout_height="match_parent"-->
+    <!--    app:layout_constraintTop_toTopOf="parent"-->
+    <!--    app:layout_constraintBottom_toBottomOf="parent"-->
+    <!--    app:layout_constraintStart_toStartOf="parent"-->
+    <!--    app:layout_constraintEnd_toEndOf="parent"-->
+    <!--    tools:layout="@layout/fragment_news" />-->
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/swiperefresh"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <FrameLayout
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <ProgressBar
+                android:id="@+id/progress_circular"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center" />
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/news_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+                tools1:listitem="@layout/article_list_item" />
+
+
+        </FrameLayout>
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+    <!-- Fragment Container -->
+    <!--    <androidx.fragment.app.FragmentContainerView-->
+    <!--        android:id="@+id/fragment_container"-->
+    <!--        android:layout_width="0dp"-->
+    <!--        android:layout_height="0dp"-->
+    <!--        app:layout_constraintBottom_toBottomOf="parent"-->
+    <!--        app:layout_constraintStart_toStartOf="parent"-->
+    <!--        app:layout_constraintEnd_toEndOf="parent" />-->
 
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_sign_in.xml
+++ b/app/src/main/res/layout/fragment_sign_in.xml
@@ -1,0 +1,128 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".presentation.authentication.SignInFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/white"
+        android:orientation="vertical"
+        android:paddingStart="32dp"
+        android:paddingEnd="32dp"
+        android:gravity="center_horizontal">
+
+        <!-- 1. Logo/Header Area -->
+        <ImageView
+            android:id="@+id/logo_header"
+            android:layout_width="150dp"
+            android:layout_height="60dp"
+            android:layout_marginTop="64dp"
+            android:contentDescription="NewsWatch Logo"
+            android:src="@drawable/ic_launcher_background"
+            tools:src="@tools:sample/avatars" />
+
+        <!-- 2. Email Input Field (Using TextInputLayout for border/radius) -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layout_email"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Email"
+            android:layout_marginTop="80dp"
+            app:hintTextColor="#00BFFF"
+            app:boxStrokeColor="#00BFFF"
+            app:endIconMode="custom"
+            app:boxCornerRadiusTopStart="8dp"
+            app:boxCornerRadiusTopEnd="8dp"
+            app:boxCornerRadiusBottomStart="8dp"
+            app:boxCornerRadiusBottomEnd="8dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_email"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textEmailAddress"
+                android:textColor="@android:color/black"
+                android:textSize="16sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- 3. Password Input Field (Using TextInputLayout for border/radius and toggle) -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layout_password"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:hint="Password"
+            app:hintTextColor="#00BFFF"
+            app:boxStrokeColor="#00BFFF"
+            app:passwordToggleEnabled="true"
+            app:boxCornerRadiusTopStart="8dp"
+            app:boxCornerRadiusTopEnd="8dp"
+            app:boxCornerRadiusBottomStart="8dp"
+            app:boxCornerRadiusBottomEnd="8dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPassword"
+                android:textColor="@android:color/black"
+                android:textSize="16sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+
+
+        <!-- 5. Sign In Button -->
+        <Button
+            android:id="@+id/button_sign_in"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:backgroundTint="#00BFFF"
+            android:text="Sign In"
+            android:textAllCaps="false"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            app:cornerRadius="8dp" />
+        <!-- 4. Forgot Password Link -->
+        <TextView
+            android:id="@+id/text_forgot_password"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_gravity="end"
+            android:text="Forgot password?"
+            android:textColor="@color/black"
+            android:textSize="14sp" />
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+        <ProgressBar
+            android:id="@+id/progress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginVertical="16dp"
+            android:visibility="invisible"
+            tools:visibility="visible" />
+        <!-- 6. Register Link -->
+        <TextView
+            android:id="@+id/text_register_full"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="32dp"
+            android:padding="8dp"
+            android:text="Don't have an account? Register"
+            android:textColor="@android:color/black"
+            android:textSize="14sp" />
+
+    </LinearLayout>
+
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_sign_up.xml
+++ b/app/src/main/res/layout/fragment_sign_up.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    tools:context=".presentation.authentication.SignUpFragment">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@android:color/white"
+        android:orientation="vertical"
+        android:paddingStart="32dp"
+        android:paddingEnd="32dp"
+        android:gravity="center_horizontal">
+
+        <!-- 1. Logo/Header Area -->
+        <ImageView
+            android:id="@+id/logo_header"
+            android:layout_width="150dp"
+            android:layout_height="60dp"
+            android:layout_marginTop="64dp"
+            android:contentDescription="NewsWatch Logo"
+            android:src="@drawable/ic_launcher_background"
+            tools:src="@tools:sample/avatars" />
+
+        <!-- Space separator (similar to the 80dp margin block in sign-in) -->
+        <Space
+            android:layout_width="match_parent"
+            android:layout_height="60dp" />
+
+        <!-- 2. Name Input Field -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layout_name"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+
+
+            android:hint="User Name"
+            app:hintTextColor="#00BFFF"
+            app:boxStrokeColor="#00BFFF"
+            app:boxCornerRadiusTopStart="8dp"
+            app:boxCornerRadiusTopEnd="8dp"
+            app:boxCornerRadiusBottomStart="8dp"
+            app:boxCornerRadiusBottomEnd="8dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPersonName"
+                android:textColor="@android:color/black"
+                android:textSize="16sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- 3. Email Input Field -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layout_email"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:hint="Email"
+            android:layout_marginTop="24dp"
+            app:hintTextColor="#00BFFF"
+            app:boxStrokeColor="#00BFFF"
+            app:boxCornerRadiusTopStart="8dp"
+            app:boxCornerRadiusTopEnd="8dp"
+            app:boxCornerRadiusBottomStart="8dp"
+            app:boxCornerRadiusBottomEnd="8dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_email"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textEmailAddress"
+                android:textColor="@android:color/black"
+                android:textSize="16sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- 4. Password Input Field -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layout_password"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:hint="Password"
+            app:hintTextColor="#00BFFF"
+            app:boxStrokeColor="#00BFFF"
+            app:passwordToggleEnabled="true"
+            app:boxCornerRadiusTopStart="8dp"
+            app:boxCornerRadiusTopEnd="8dp"
+            app:boxCornerRadiusBottomStart="8dp"
+            app:boxCornerRadiusBottomEnd="8dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPassword"
+                android:textColor="@android:color/black"
+                android:textSize="16sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- 5. Confirm Password Input Field -->
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/layout_confirm_password"
+            style="@style/Widget.MaterialComponents.TextInputLayout.OutlinedBox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:hint="Confirm Password"
+            app:hintTextColor="#00BFFF"
+            app:boxStrokeColor="#00BFFF"
+            app:passwordToggleEnabled="true"
+            app:boxCornerRadiusTopStart="8dp"
+            app:boxCornerRadiusTopEnd="8dp"
+            app:boxCornerRadiusBottomStart="8dp"
+            app:boxCornerRadiusBottomEnd="8dp">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/input_confirm_password"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:inputType="textPassword"
+                android:textColor="@android:color/black"
+                android:textSize="16sp" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <!-- 6. Sign Up Button -->
+        <Button
+            android:id="@+id/button_sign_up"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="32dp"
+            android:backgroundTint="#00BFFF"
+            android:text="Sign Up"
+            android:textAllCaps="false"
+            android:textColor="@android:color/white"
+            android:textSize="16sp"
+            app:cornerRadius="8dp" />
+
+        <!-- Empty space to push Sign In link to the bottom -->
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+        <ProgressBar
+            android:id="@+id/progress"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_marginVertical="16dp"
+            android:visibility="invisible"
+            tools:visibility="visible" />
+        <!-- 7. Sign In Link -->
+        <TextView
+            android:id="@+id/text_sign_in_full"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="32dp"
+            android:padding="8dp"
+            android:text="Already have an account? Sign In"
+            android:textColor="@android:color/black"
+            android:textSize="14sp" />
+
+    </LinearLayout>
+
+</FrameLayout>

--- a/app/src/main/res/navigation/app_nav.xml
+++ b/app/src/main/res/navigation/app_nav.xml
@@ -1,8 +1,34 @@
 <?xml version="1.0" encoding="utf-8"?>
 <navigation xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/app_nav"
-    app:startDestination="@id/placeholder">
+    app:startDestination="@id/signInFragment">
 
-    <fragment android:id="@+id/placeholder" />
+    <fragment
+        android:id="@+id/signInFragment"
+        android:name="com.darsh.news.presentation.authentication.SignInFragment"
+        android:label="fragment_sign_in"
+        tools:layout="@layout/fragment_sign_in" >
+        <action
+            android:id="@+id/action_signInFragment_to_signUpFragment2"
+            app:destination="@id/signUpFragment2" />
+        <action
+            android:id="@+id/action_signInFragment_to_favouritFragment"
+            app:destination="@id/favouritFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/signUpFragment2"
+        android:name="com.darsh.news.presentation.authentication.SignUpFragment"
+        android:label="fragment_sign_up"
+        tools:layout="@layout/fragment_sign_up" >
+        <action
+            android:id="@+id/action_signUpFragment2_to_signInFragment"
+            app:destination="@id/signInFragment" />
+    </fragment>
+    <fragment
+        android:id="@+id/favouritFragment"
+        android:name="com.darsh.news.presentation.newsList.favouritFragment"
+        android:label="fragment_favourit"
+        tools:layout="@layout/fragment_favourit" />
 </navigation>

--- a/app/src/main/res/navigation/app_nav.xml
+++ b/app/src/main/res/navigation/app_nav.xml
@@ -14,8 +14,8 @@
             android:id="@+id/action_signInFragment_to_signUpFragment2"
             app:destination="@id/signUpFragment2" />
         <action
-            android:id="@+id/action_signInFragment_to_favouritFragment"
-            app:destination="@id/favouritFragment" />
+            android:id="@+id/action_signInFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
     </fragment>
     <fragment
         android:id="@+id/signUpFragment2"
@@ -31,4 +31,20 @@
         android:name="com.darsh.news.presentation.newsList.favouritFragment"
         android:label="fragment_favourit"
         tools:layout="@layout/fragment_favourit" />
+    <fragment
+        android:id="@+id/newsFragment"
+        android:name="com.darsh.news.presentation.newsList.NewsFragment"
+        android:label="NewsFragment" />
+    <fragment
+        android:id="@+id/homeFragment"
+        android:name="com.darsh.news.presentation.home.HomeFragment"
+        android:label="fragment_home"
+        tools:layout="@layout/fragment_home" >
+        <action
+            android:id="@+id/action_homeFragment_to_favouritFragment"
+            app:destination="@id/favouritFragment" />
+        <action
+            android:id="@+id/action_homeFragment_to_newsFragment"
+            app:destination="@id/newsFragment" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -2,4 +2,6 @@
     <string name="app_name">News</string>
     <string name="news_image_content_description" />
     <string name="share_news_content_description">Share</string>
+    <!-- TODO: Remove or change this placeholder text -->
+    <string name="hello_blank_fragment">Hello blank fragment</string>
 </resources>


### PR DESCRIPTION
**Key Changes:**

* **Creating the Authentication Directory:**
    * Implemented the **authentication directory** to hold the **`SignUpFragment`** and **`SignInFragment`** with necessary input **validation**.
* **Creating the Home Activity:**
    * Created the **`HomeActivity`** and set it as the app's starting point for **testing purposes** only.
* **Creating the Favorite Fragment:**
    * Created the **`Favorite Fragment`** with the same design as the previous news list. It reuses the same adapter but is designed to receive **favorite news items from the API** upon instantiation.
    * Includes a **back button** to navigate to the main **`Home Fragment`**.
* **Navigation Changes (nav\_app):**
    * Modified the **`nav_app`** file.
    * **Note for Testing:** While sign-in should eventually navigate to the `Home Fragment`, it is currently set to navigate to the **`Favorite Fragment`** for testing the new flow.